### PR TITLE
Some CMake improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,5 @@
+PROJECT(OpenAmbit)
+
+cmake_minimum_required(VERSION 2.8)
+
+add_subdirectory("src")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,0 +1,2 @@
+add_subdirectory("libambit")
+add_subdirectory("openambit")

--- a/src/libambit/CMakeLists.txt
+++ b/src/libambit/CMakeLists.txt
@@ -1,8 +1,8 @@
-cmake_minimum_required (VERSION 2.8.5)
-project (LIBAMBIT)
+cmake_minimum_required(VERSION 2.8.5)
+project(libAmbit)
 
 # Where to lookup modules
-set(CMAKE_MODULE_PATH "${LIBAMBIT_SOURCE_DIR}/cmake")
+set(CMAKE_MODULE_PATH "${libAmbit_SOURCE_DIR}/cmake")
 
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall")
 
@@ -19,7 +19,7 @@ find_package(libusb REQUIRED)
 find_package(UDev REQUIRED)
 include(GNUInstallDirs)
 
-add_library (
+add_library(
   ambit
   SHARED
   crc16.c
@@ -38,6 +38,7 @@ target_link_libraries(
   m
 )
 
+set(LIBAMBIT_LIBS ${CMAKE_CURRENT_BINARY_DIR})
 set_target_properties(ambit PROPERTIES VERSION 0.3.0 SOVERSION 0)
 
 include_directories(

--- a/src/openambit/CMakeLists.txt
+++ b/src/openambit/CMakeLists.txt
@@ -1,10 +1,10 @@
 cmake_minimum_required(VERSION 2.8.5)
-project (OPENAMBIT)
+project(OpenAmbitQt)
 
-set (OPENAMBIT_VERSION HEAD)
+set(OpenAmbitQt_VERSION HEAD)
 
 # Where to lookup modules
-set(CMAKE_MODULE_PATH "${OPENAMBIT_SOURCE_DIR}/cmake")
+set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")
 
@@ -17,8 +17,9 @@ find_package(QJSON 0.8.0 REQUIRED)
 include(${QT_USE_FILE})
 include(GNUInstallDirs)
 
-include_directories (
-  ${CMAKE_SOURCE_DIR} ${CMAKE_CURRENT_BINARY_DIR}
+include_directories(
+  ${CMAKE_CURRENT_SOURCE_DIR}
+  ${CMAKE_CURRENT_BINARY_DIR}
   ${QT_QTCORE_INCLUDE_DIR}
   ${QT_QTGUI_INCLUDE_DIR}
   ${QT_QTNETWORK_INCLUDE_DIR}
@@ -29,11 +30,11 @@ link_directories(
   ${LIBAMBIT_LIBS_DIR}
 )
 
-set ( openambit_HDRS
+set( OpenAmbitQt_HDRS
   logentry.h
 )
 
-set ( openambit_SRCS
+set( OpenAmbitQt_SRCS
   confirmbetadialog.cpp
   devicemanager.cpp
   logentry.cpp
@@ -47,17 +48,18 @@ set ( openambit_SRCS
   udevlistener.cpp
 )
 
-set ( openambit_UIS
+set( OpenAmbitQt_UIS
   confirmbetadialog.ui
   mainwindow.ui
   settingsdialog.ui
 )
 
-set ( openambit_RSCS
+set( OpenAmbitQt_RSCS
   resources.qrc
 )
 
-set ( openambit_MOCS
+set( OpenAmbitQt_MOCS
+  mainwindow.h
   confirmbetadialog.h
   devicemanager.h
   logstore.h
@@ -69,26 +71,30 @@ set ( openambit_MOCS
   udevlistener.h
 )
 
-set (FILES_TO_TRANSLATE ${openambit_SRCS} ${openambit_UIS} ${openambit_HDRS} ${openambit_MOCS})
+set(FILES_TO_TRANSLATE ${openambit_SRCS} ${openambit_UIS} ${openambit_HDRS} ${openambit_MOCS})
 
-set ( APP_ICON ${PROJECT_SOURCE_DIR}/icons/icon_disconnected.png )
+set(APP_ICON ${PROJECT_SOURCE_DIR}/icons/icon_disconnected.png )
 
-set ( CMAKE_INSTALL_UDEVRULESDIR /lib/udev/rules.d
+set( CMAKE_INSTALL_UDEVRULESDIR /lib/udev/rules.d
       CACHE PATH "Where to install udev rules"
 )
-mark_as_advanced ( CMAKE_INSTALL_UDEVRULESDIR )
+mark_as_advanced( CMAKE_INSTALL_UDEVRULESDIR )
 
 add_subdirectory("${PROJECT_SOURCE_DIR}/movescount")
 
-######### Translations
-file (GLOB TRANSLATIONS_FILES translations/*.ts)
+QT4_WRAP_UI(UIS ${OpenAmbitQt_UIS})
+QT4_ADD_RESOURCES(RSCS ${OpenAmbitQt_RSCS})
+QT4_WRAP_CPP(MOCS ${OpenAmbitQt_MOCS})
 
-option (UPDATE_TRANSLATIONS "Update source translation translations/*.ts")
-if (UPDATE_TRANSLATIONS)
+######### Translations
+file(GLOB TRANSLATIONS_FILES translations/*.ts)
+
+option(UPDATE_TRANSLATIONS "Update source translation translations/*.ts")
+if(UPDATE_TRANSLATIONS)
   qt4_create_translation(QM_FILES ${FILES_TO_TRANSLATE} ${TRANSLATIONS_FILES})
-else (UPDATE_TRANSLATIONS)
+else(UPDATE_TRANSLATIONS)
   qt4_add_translation(QM_FILES ${TRANSLATIONS_FILES})
-endif (UPDATE_TRANSLATIONS)
+endif(UPDATE_TRANSLATIONS)
 
 # Create translations QRC file - ts.qrc
 set(TRANSLATIONS_QRC "${CMAKE_CURRENT_BINARY_DIR}/ts.qrc")
@@ -105,24 +111,25 @@ set_directory_properties(PROPERTIES CLEAN_NO_CUSTOM true)
 
 ######### Translations
 
-QT4_WRAP_UI(UIS ${openambit_UIS})
-QT4_ADD_RESOURCES(RSCS ${openambit_RSCS})
-QT4_WRAP_CPP(MOCS ${openambit_MOCS})
+QT4_WRAP_UI(UIS ${OpenAmbitQt_UIS})
+QT4_ADD_RESOURCES(RSCS ${OpenAmbitQt_RSCS})
+QT4_WRAP_CPP(MOCS ${OpenAmbitQt_MOCS})
 
-add_definitions( -DAPP_VERSION="${OPENAMBIT_VERSION}" )
+add_definitions( -DAPP_VERSION="${OpenAmbitQt_VERSION}" )
 
-add_executable ( openambit ${openambit_SRCS} ${UIS} ${RSCS} ${MOCS} )
+add_executable( openambit ${OpenAmbitQt_SRCS} ${UIS} ${RSCS} ${TRS} ${MOCS} )
 
-target_link_libraries ( openambit  ${QT_QTCORE_LIBRARY} ${QT_QTGUI_LIBRARY} ${QT_QTNETWORK_LIBRARY} ${LIBAMBIT_LIBS} ${UDEV_LIBS} ${ZLIB_LIBRARY} ${QJSON_LIBRARIES} )
+target_link_libraries( openambit ${QT_QTCORE_LIBRARY} ${QT_QTGUI_LIBRARY} ${QT_QTNETWORK_LIBRARY} ${LIBAMBIT_LIBS} ${UDEV_LIBS} ${ZLIB_LIBRARY} ${QJSON_LIBRARIES} )
 
-install ( TARGETS openambit DESTINATION ${CMAKE_INSTALL_BINDIR} )
-install ( FILES ${OPENAMBIT_SOURCE_DIR}/deployment/99-suunto-ambit.rules
+install( TARGETS openambit DESTINATION ${CMAKE_INSTALL_BINDIR} )
+install( FILES ${CMAKE_CURRENT_SOURCE_DIR}/deployment/99-suunto-ambit.rules
           DESTINATION ${CMAKE_INSTALL_UDEVRULESDIR}
           COMPONENT system
 )
-install ( FILES ${OPENAMBIT_SOURCE_DIR}/deployment/openambit.desktop
-          DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/applications )
-install ( FILES ${APP_ICON}
+install( FILES ${CMAKE_CURRENT_SOURCE_DIR}/deployment/openambit.desktop
+          DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/applications
+)
+install( FILES ${APP_ICON}
           DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/icons/hicolor/64x64/apps
-          RENAME openambit.png )
-
+          RENAME openambit.png
+)

--- a/src/openambit/cmake/Findlibambit.cmake
+++ b/src/openambit/cmake/Findlibambit.cmake
@@ -8,6 +8,7 @@
 find_path(LIBAMBIT_INCLUDE_DIR NAMES libambit.h
   PATHS
   ../libambit
+  ${CMAKE_SOURCE_DIR}/src/libambit
 )
 
 find_library(LIBAMBIT_LIBS_PATH NAMES libambit.so
@@ -26,6 +27,10 @@ if(LIBAMBIT_INCLUDE_DIR AND LIBAMBIT_LIBS)
 else(LIBAMBIT_INCLUDE_DIR AND LIBAMBIT_LIBS)
   set(LIBAMBIT_FOUND FALSE CACHE INTERNAL "libambit found")
   message(STATUS "libambit not found.")
+
+  set(LIBAMBIT_INCLUDE_DIR ${CMAKE_SOURCE_DIR}/src/libambit/)
+  set(LIBAMBIT_LIBS ${CMAKE_BINARY_DIR}/src/libambit/libambit.so.0)
+  set(LIBAMBIT_FOUND true)
 endif(LIBAMBIT_INCLUDE_DIR AND LIBAMBIT_LIBS)
 
 mark_as_advanced(LIBAMBIT_INCLUDE_DIR LIBAMBIT_LIBS)

--- a/src/openambit/movescount/CMakeLists.txt
+++ b/src/openambit/movescount/CMakeLists.txt
@@ -1,5 +1,5 @@
-set ( openambit_SRCS
-  ${openambit_SRCS}
+set ( OpenAmbitQt_SRCS
+  ${OpenAmbitQt_SRCS}
   ${CMAKE_CURRENT_SOURCE_DIR}/movescount.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/movescountjson.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/movescountlogchecker.cpp
@@ -8,8 +8,8 @@ set ( openambit_SRCS
   PARENT_SCOPE
 )
 
-set ( openambit_MOCS
-  ${openambit_MOCS}
+set ( OpenAmbitQt_MOCS
+  ${OpenAmbitQt_MOCS}
   ${CMAKE_CURRENT_SOURCE_DIR}/movescount.h
   ${CMAKE_CURRENT_SOURCE_DIR}/movescountjson.h
   ${CMAKE_CURRENT_SOURCE_DIR}/movescountlogchecker.h


### PR DESCRIPTION
Added a global project file to allow building both libambit and openambit at the same time

Added a fallback mechanism for finding libambit in the local build tree

There are also some small changes to the cmake project names casing. 

The build process is still compatible with the ./build.sh and ./install.sh scripts, but can also be built in one go, in or out of tree, using plain cmake and make.
