### PR TITLE
Desktop file fixes

### DIFF
--- a/src/openambit/deployment/openambit.desktop
+++ b/src/openambit/deployment/openambit.desktop
@@ -1,9 +1,9 @@
 [Desktop Entry]
-Version=HEAD
+Version=1.0
 Type=Application
 Name=Openambit
 Comment=Open source synchronization for Suunto Ambit series
 TryExec=openambit
 Exec=openambit
 Icon=openambit
-Categories=Utility;Education;Sports
+Categories=Utility;Education;Sports;


### PR DESCRIPTION
This commit fixes two errors reported by `desktop-file-validate`:

    $ desktop-file-validate openambit.desktop 
    openambit.desktop: error: value "HEAD" for key "Version" in group "Desktop Entry" is not a known version
    openambit.desktop: error: value "Utility;Education;Sports" for string list key "Categories" in group "Desktop Entry" does not have a semicolon (';') as trailing character
