### PR TITLE
Make movescount compilable with cmake versions <3.0

### DIFF
--- a/src/movescount/CMakeLists.txt
+++ b/src/movescount/CMakeLists.txt
@@ -17,10 +17,9 @@
 #  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 2.8.5)
 
-project(movescount
-  LANGUAGES CXX)
+project(movescount CXX) 
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")
 set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../openambit/cmake")


### PR DESCRIPTION
Decreases the minimal required cmake version to 2.8.5 and fixes a malformed language environment variable definition. With the changed form the project builds without errors on Ubuntu 12.04 with cmake 2.8.12.