### PR TITLE
Added tooltip displaying the sync/charge status to the trayIcon

### DIFF
--- a/src/openambit/mainwindow.cpp
+++ b/src/openambit/mainwindow.cpp
@@ -88,6 +88,7 @@ MainWindow::MainWindow(QWidget *parent) :
     connect(trayIcon, SIGNAL(activated(QSystemTrayIcon::ActivationReason)), this, SLOT(trayIconClicked(QSystemTrayIcon::ActivationReason)));
     trayIcon->setVisible(true);
 
+
     // Setup device manager
     deviceManager = new DeviceManager();
     deviceManager->moveToThread(&deviceWorkerThread);
@@ -312,13 +313,14 @@ void MainWindow::deviceRemoved(void)
     ui->buttonSyncNow->setHidden(true);
     trayIconSyncAction->setDisabled(true);
     ui->syncProgressBar->setHidden(true);
-
+    trayIcon->toolTip();
     trayIcon->setIcon(QIcon(":/icon_disconnected"));
 }
 
 void MainWindow::deviceCharge(quint8 percent)
 {
     ui->chargeIndicator->setValue(percent);
+    trayIcon->setToolTip(QString(tr("Charging %1%")).arg(percent));
 }
 
 void MainWindow::syncFinished(bool success)
@@ -375,6 +377,7 @@ void MainWindow::syncProgressInform(QString message, bool error, bool newRow, qu
         }
     }
     ui->syncProgressBar->setValue(percentDone);
+    trayIcon->setToolTip(QString(tr("Downloading %1%")).arg(percentDone));
 }
 
 void MainWindow::newerFirmwareExists(QByteArray fw_version)

--- a/src/openambit/mainwindow.cpp
+++ b/src/openambit/mainwindow.cpp
@@ -88,7 +88,6 @@ MainWindow::MainWindow(QWidget *parent) :
     connect(trayIcon, SIGNAL(activated(QSystemTrayIcon::ActivationReason)), this, SLOT(trayIconClicked(QSystemTrayIcon::ActivationReason)));
     trayIcon->setVisible(true);
 
-
     // Setup device manager
     deviceManager = new DeviceManager();
     deviceManager->moveToThread(&deviceWorkerThread);
@@ -313,6 +312,7 @@ void MainWindow::deviceRemoved(void)
     ui->buttonSyncNow->setHidden(true);
     trayIconSyncAction->setDisabled(true);
     ui->syncProgressBar->setHidden(true);
+
     trayIcon->toolTip();
     trayIcon->setIcon(QIcon(":/icon_disconnected"));
 }

--- a/src/openambit/translations/openambit_de.ts
+++ b/src/openambit/translations/openambit_de.ts
@@ -257,12 +257,12 @@ p, li { white-space: pre-wrap; }
     <name>QObject</name>
     <message>
         <source>The file is not an openambit version 1.0 file.</source>
-        <translation type="obsolete">Die Datei hat nicht die Openambit-Version 1.0.</translation>
+        <translation>Die Datei hat nicht die Openambit-Version 1.0.</translation>
     </message>
     <message>
         <source>%1
 Line %2, column %3</source>
-        <translation type="obsolete">%1
+        <translation>%1
 Zeile %2, Spalte %3</translation>
     </message>
 </context>

--- a/src/openambit/translations/openambit_de.ts
+++ b/src/openambit/translations/openambit_de.ts
@@ -244,17 +244,25 @@ p, li { white-space: pre-wrap; }
         <source>Syncronisation started</source>
         <translation>Synchronisierung gestartet</translation>
     </message>
+    <message>
+        <source>Charging %1%</source>
+        <translation>Laden %1%</translation>
+    </message>
+    <message>
+        <source>Downloading %1%</source>
+        <translation>Synchronisieren %1%</translation>
+    </message>
 </context>
 <context>
     <name>QObject</name>
     <message>
         <source>The file is not an openambit version 1.0 file.</source>
-        <translation>Die Datei hat nicht die Openambit-Version 1.0.</translation>
+        <translation type="obsolete">Die Datei hat nicht die Openambit-Version 1.0.</translation>
     </message>
     <message>
         <source>%1
 Line %2, column %3</source>
-        <translation>%1
+        <translation type="obsolete">%1
 Zeile %2, Spalte %3</translation>
     </message>
 </context>

--- a/src/openambit/translations/openambit_fr.ts
+++ b/src/openambit/translations/openambit_fr.ts
@@ -248,12 +248,12 @@ p, li { white-space: pre-wrap; }
     <name>QObject</name>
     <message>
         <source>The file is not an openambit version 1.0 file.</source>
-        <translation type="obsolete">Ce fichier n&apos;est pas un fichier Openambit version 1.0</translation>
+        <translation>Ce fichier n&apos;est pas un fichier Openambit version 1.0</translation>
     </message>
     <message>
         <source>%1
 Line %2, column %3</source>
-        <translation type="obsolete">%1
+        <translation>%1
 Ligne %2, colonne %3</translation>
     </message>
 </context>

--- a/src/openambit/translations/openambit_fr.ts
+++ b/src/openambit/translations/openambit_fr.ts
@@ -235,17 +235,25 @@ p, li { white-space: pre-wrap; }
         <source>&amp;Settings</source>
         <translation>&amp;Réglages</translation>
     </message>
+    <message>
+        <source>Charging %1%</source>
+        <translation>Charge %1%</translation>
+    </message>
+    <message>
+        <source>Downloading %1%</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>QObject</name>
     <message>
         <source>The file is not an openambit version 1.0 file.</source>
-        <translation>Ce fichier n&apos;est pas un fichier Openambit version 1.0</translation>
+        <translation type="obsolete">Ce fichier n&apos;est pas un fichier Openambit version 1.0</translation>
     </message>
     <message>
         <source>%1
 Line %2, column %3</source>
-        <translation>%1
+        <translation type="obsolete">%1
 Ligne %2, colonne %3</translation>
     </message>
 </context>

--- a/src/openambit/translations/openambit_it.ts
+++ b/src/openambit/translations/openambit_it.ts
@@ -244,17 +244,25 @@ p, li { white-space: pre-wrap; }
         <source>Syncronisation started</source>
         <translation>Sincronizzazione iniziata</translation>
     </message>
+    <message>
+        <source>Charging %1%</source>
+        <translation>Carica %1%</translation>
+    </message>
+    <message>
+        <source>Downloading %1%</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>QObject</name>
     <message>
         <source>The file is not an openambit version 1.0 file.</source>
-        <translation>Il file non é un file openambit versione 1.0.</translation>
+        <translation type="obsolete">Il file non é un file openambit versione 1.0.</translation>
     </message>
     <message>
         <source>%1
 Line %2, column %3</source>
-        <translation>%1
+        <translation type="obsolete">%1
 riga %2, colonna %3</translation>
     </message>
 </context>

--- a/src/openambit/translations/openambit_it.ts
+++ b/src/openambit/translations/openambit_it.ts
@@ -257,12 +257,12 @@ p, li { white-space: pre-wrap; }
     <name>QObject</name>
     <message>
         <source>The file is not an openambit version 1.0 file.</source>
-        <translation type="obsolete">Il file non é un file openambit versione 1.0.</translation>
+        <translation>Il file non é un file openambit versione 1.0.</translation>
     </message>
     <message>
         <source>%1
 Line %2, column %3</source>
-        <translation type="obsolete">%1
+        <translation>%1
 riga %2, colonna %3</translation>
     </message>
 </context>

--- a/src/openambit/translations/openambit_ja.ts
+++ b/src/openambit/translations/openambit_ja.ts
@@ -226,6 +226,14 @@ p, li { white-space: pre-wrap; }
         <source>Syncronisation started</source>
         <translation>同期開始</translation>
     </message>
+    <message>
+        <source>Charging %1%</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Downloading %1%</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>SettingsDialog</name>

--- a/src/openambit/translations/openambit_nl.ts
+++ b/src/openambit/translations/openambit_nl.ts
@@ -226,6 +226,14 @@ p, li { white-space: pre-wrap; }
         <source>Syncronisation started</source>
         <translation>Synchronisatie gestart</translation>
     </message>
+    <message>
+        <source>Charging %1%</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Downloading %1%</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>SettingsDialog</name>

--- a/src/openambit/translations/openambit_pl.ts
+++ b/src/openambit/translations/openambit_pl.ts
@@ -257,12 +257,12 @@ p, li { white-space: pre-wrap; }
     <name>QObject</name>
     <message>
         <source>The file is not an openambit version 1.0 file.</source>
-        <translation type="obsolete">To nie jest plik openambit w wersji 1.0.</translation>
+        <translation>To nie jest plik openambit w wersji 1.0.</translation>
     </message>
     <message>
         <source>%1
 Line %2, column %3</source>
-        <translation type="obsolete">%1
+        <translation>%1
 Linia %2, kolumna %3</translation>
     </message>
 </context>

--- a/src/openambit/translations/openambit_pl.ts
+++ b/src/openambit/translations/openambit_pl.ts
@@ -244,17 +244,25 @@ p, li { white-space: pre-wrap; }
         <source>Syncronisation started</source>
         <translation>Synchronizacja rozpoczęta</translation>
     </message>
+    <message>
+        <source>Charging %1%</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Downloading %1%</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>QObject</name>
     <message>
         <source>The file is not an openambit version 1.0 file.</source>
-        <translation>To nie jest plik openambit w wersji 1.0.</translation>
+        <translation type="obsolete">To nie jest plik openambit w wersji 1.0.</translation>
     </message>
     <message>
         <source>%1
 Line %2, column %3</source>
-        <translation>%1
+        <translation type="obsolete">%1
 Linia %2, kolumna %3</translation>
     </message>
 </context>

--- a/src/openambit/translations/openambit_sv.ts
+++ b/src/openambit/translations/openambit_sv.ts
@@ -246,12 +246,12 @@ p, li { white-space: pre-wrap; }
     <name>QObject</name>
     <message>
         <source>The file is not an openambit version 1.0 file.</source>
-        <translation type="obsolete">Filen är inte i openambit version 1.0-format.</translation>
+        <translation>Filen är inte i openambit version 1.0-format.</translation>
     </message>
     <message>
         <source>%1
 Line %2, column %3</source>
-        <translation type="obsolete">%1
+        <translation>%1
 Rad %2, kolumn %3</translation>
     </message>
 </context>

--- a/src/openambit/translations/openambit_sv.ts
+++ b/src/openambit/translations/openambit_sv.ts
@@ -233,17 +233,25 @@ p, li { white-space: pre-wrap; }
         <source>&amp;Settings</source>
         <translation>&amp;Inställningar</translation>
     </message>
+    <message>
+        <source>Charging %1%</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Downloading %1%</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>QObject</name>
     <message>
         <source>The file is not an openambit version 1.0 file.</source>
-        <translation>Filen är inte i openambit version 1.0-format.</translation>
+        <translation type="obsolete">Filen är inte i openambit version 1.0-format.</translation>
     </message>
     <message>
         <source>%1
 Line %2, column %3</source>
-        <translation>%1
+        <translation type="obsolete">%1
 Rad %2, kolumn %3</translation>
     </message>
 </context>


### PR DESCRIPTION
I've added a tooltip to the tray icon that displays the percentage of sync or charge completion while syncing/charging. Hence it is not necessary to switch to the openambit window to see how far the sync or charge process are done. Instead it's sufficient to hover with the mouse over the tray icon.

I've also added the respective translations as far as I was able to do so.