### PR TITLE
Bugfix for automatically sync when watch is connected.

### DIFF
--- a/src/openambit/mainwindow.cpp
+++ b/src/openambit/mainwindow.cpp
@@ -289,10 +289,11 @@ void MainWindow::deviceDetected(const DeviceInfo& deviceInfo)
         }
 
         settings.beginGroup("syncSettings");
-        if (settings.value("syncAutomatically", false).toBool()) {
+        bool syncAutomatically = settings.value("syncAutomatically", false).toBool();
+        settings.endGroup();
+        if (syncAutomatically) {
             startSync();
         }
-        settings.endGroup();
     }
 }
 


### PR DESCRIPTION
From MainWindow::deviceDetected() settings.beginGroup() is called and then SyncStart() is called.
SyncStart() will also called settings.beginGroup() before settings.endGroup() has been called from MainWindow::deviceDetected(). 
This will resulted in that the settings is not correctly read and that no automatic sync with movescount is done.