### PR TITLE
Fixed error when uploading existing log.

### DIFF
--- a/src/movescount/movescount.cpp
+++ b/src/movescount/movescount.cpp
@@ -340,14 +340,14 @@ void MovesCount::writeLogInThread(LogEntry *logEntry)
 
     reply = syncPOST("/moves/", "", output, true);
 
-    if (reply->error() == QNetworkReply::NoError) {
+    if (reply->error() == QNetworkReply::NoError || reply->error() == QNetworkReply::UnknownContentError) {
         QByteArray data = reply->readAll();
         if (jsonParser.parseLogReply(data, moveId) == 0) {
             emit logMoveID(logEntry->device, logEntry->time, moveId);
         }
-    }
+    } 
     else {
-        qDebug() << "Failed to upload log, movescount.com replied with \"" << reply->readAll() << "\"";
+        qDebug() << "Failed to upload log (err code:" << reply->error() << "), movescount.com replied with \"" << reply->readAll() << "\"";
     }
 }
 


### PR DESCRIPTION
This fix will allow openambit to update xml-file with MoveID even if log is uploaded with another client.
uiservices.movecounts.com return unknown content error when log i uploaded before.