### PR TITLE
Fixes for use with python 3 if that is your system default

### DIFF
--- a/wireshark_dissector/tools/make-dissector-reg.py
+++ b/wireshark_dissector/tools/make-dissector-reg.py
@@ -10,6 +10,7 @@
 # less processes would have to be started.
 #
 # $Id: make-dissector-reg.py 30447 2009-10-09 20:47:18Z krj $
+from __future__ import print_function
 
 import os
 import sys
@@ -59,7 +60,7 @@ elif registertype == "dissectors":
  */
 """
 else:
-	print "Unknown output type '%s'" % registertype
+	print("Unknown output type '%s'".format(registertype))
 	sys.exit(1)
 
 
@@ -77,7 +78,7 @@ for file in files:
 		filenames.append(os.path.join(srcdir, file))
 
 if len(filenames) < 1:
-	print "No files found"
+	print("No files found")
 	sys.exit(1)
 
 
@@ -130,7 +131,7 @@ for filename in filenames:
 	if cache and cache.has_key(filename):
 		cdict = cache[filename]
 		if cur_mtime == cdict['mtime']:
-#			print "Pulling %s from cache" % (filename)
+#			print("Pulling %s from cache" % (filename))
 			regs['proto_reg'].extend(cdict['proto_reg'])
 			regs['handoff_reg'].extend(cdict['handoff_reg'])
 			regs['wtap_register'].extend(cdict['wtap_register'])
@@ -144,7 +145,7 @@ for filename in filenames:
 			'handoff_reg': [],
 			'wtap_register': [],
 			}
-#	print "Searching %s" % (filename)
+#	print("Searching %s" % (filename))
 	for line in file.readlines():
 		for action in patterns:
 			regex = action[1]
@@ -154,7 +155,7 @@ for filename in filenames:
 				sym_type = action[0]
 				regs[sym_type].append(symbol)
 				if cache is not None:
-#					print "Caching %s for %s: %s" % (sym_type, filename, symbol)
+#					print("Caching %s for %s: %s" % (sym_type, filename, symbol))
 					cache[filename][sym_type].append(symbol)
 	file.close()
 
@@ -165,7 +166,7 @@ if cache is not None and cache_filename is not None:
 
 # Make sure we actually processed something
 if len(regs['proto_reg']) < 1:
-	print "No protocol registrations found"
+	print("No protocol registrations found")
 	sys.exit(1)
 
 # Sort the lists to make them pretty
@@ -252,7 +253,7 @@ register_wtap_module(void)
 		reg_code.write(line)
 
 	reg_code.write("}\n");
-        reg_code.write("#endif\n");
+	reg_code.write("#endif\n");
 else:
 	reg_code.write("""
 static gulong proto_reg_count(void)


### PR DESCRIPTION
Arch Linux uses Python 3 by default, for instance.