### PR TITLE
Better error handling in writeLogInThread

### DIFF
--- a/src/movescount/movescount.cpp
+++ b/src/movescount/movescount.cpp
@@ -512,6 +512,8 @@ void MovesCount::writeLogInThread(LogEntry *logEntry)
         QByteArray data = reply->readAll();
         if (jsonParser.parseLogReply(data, moveId) == 0) {
             emit logMoveID(logEntry->device, logEntry->time, moveId);
+        } else {
+            qDebug() << "Failed to upload log, movescount.com replied with \"" << reply->readAll() << "\"";
         }
     } 
     else {


### PR DESCRIPTION
I found out that my fix in pull #123 did suppress some valid error messages. This is fixed in this pull request.