### PR TITLE
Fix log writing

### DIFF
--- a/src/movescount/movescountxml.cpp
+++ b/src/movescount/movescountxml.cpp
@@ -164,6 +164,7 @@ MovesCountXML::MovesCountXML(QObject *parent) :
     QObject(parent)
 {
     storagePath = QString(getenv("HOME")) + "/.openambit/movescount";
+    QDir().mkpath(storagePath);
 }
 
 void MovesCountXML::writeLog(LogEntry *logEntry)


### PR DESCRIPTION
The folder to save logs was not created leading to error when writing
log files.