### PR TITLE
Fix use of time related functions (related to #206)

### DIFF
--- a/src/libambit/pmem20.c
+++ b/src/libambit/pmem20.c
@@ -1162,12 +1162,11 @@ static void add_time(ambit_date_time_t *intime, int32_t offset, ambit_date_time_
     outtime->minute = tm->tm_min;
     outtime->hour = tm->tm_hour;
     outtime->day = tm->tm_mday;
-    outtime->month = tm->tm_mon;
-    outtime->year = tm->tm_year;
+    outtime->month = tm->tm_mon + 1;
+    outtime->year = tm->tm_year + 1900;
 }
 
 static int is_leap(unsigned int y) {
-    y += 1900;
     return (y % 4) == 0 && ((y % 100) != 0 || (y % 400) == 0);
 }
 
@@ -1180,11 +1179,11 @@ static void to_timeval(ambit_date_time_t *ambit_time, struct timeval *timeval) {
     timeval->tv_usec = 0;
     int i;
 
-    for (i = 70; i < ambit_time->year; ++i) {
+    for (i = 1970; i < ambit_time->year; ++i) {
         timeval->tv_sec += is_leap(i) ? 366 : 365;
     }
 
-    for (i = 0; i < ambit_time->month; ++i) {
+    for (i = 0; i < ambit_time->month-1; ++i) {
         timeval->tv_sec += ndays[is_leap(ambit_time->year)][i];
     }
     timeval->tv_sec += ambit_time->day - 1;


### PR DESCRIPTION
Previously this was misusing the tm structure returned from gmtime(),
 since the result is "years since 1900" and "months since January" (i.e. 0-11),
 but the ambit_date_time is standard Gregorian years and months (1-12).

Thus suitably adjust the result from gmtime() and remove the previous bodge factors.

Somehow the previous code worked for some (most?) dates,
 but definitely fails in December 2018 - leading to unreal dates and thus
blank UTC fields in the openambit log files.