### PR TITLE
Display a warning dialog when a move fails to upload

### DIFF
--- a/src/movescount/movescount.h
+++ b/src/movescount/movescount.h
@@ -72,6 +72,7 @@ signals:
     void newerFirmwareExists(QByteArray fw_version);
     void movesCountAuth(bool authorized);
     void logMoveID(QString device, QDateTime time, QString moveID);
+    void uploadError(QByteArray data);
 
 private slots:
     void authCheckFinished();

--- a/src/openambit/mainwindow.cpp
+++ b/src/openambit/mainwindow.cpp
@@ -400,6 +400,11 @@ void MainWindow::movesCountAuth(bool authorized)
     ui->labelMovescountAuthIcon->setHidden(authorized);
 }
 
+void MainWindow::showUploadError(QByteArray data)
+{
+    QMessageBox::warning(nullptr, QObject::tr("Upload error"), data, QMessageBox::Ok);
+}
+
 void MainWindow::logItemSelected(QListWidgetItem *current,QListWidgetItem *previous)
 {
     LogEntry *logEntry = NULL;
@@ -517,6 +522,7 @@ void MainWindow::movesCountSetup()
 
             connect(movesCount, SIGNAL(newerFirmwareExists(QByteArray)), this, SLOT(newerFirmwareExists(QByteArray)), Qt::QueuedConnection);
             connect(movesCount, SIGNAL(movesCountAuth(bool)), this, SLOT(movesCountAuth(bool)), Qt::QueuedConnection);
+            connect(movesCount, SIGNAL(uploadError(QByteArray)), this, SLOT(showUploadError(QByteArray)));
         }
         if (movescountEnable) {
             movesCount->setUsername(settings.value("email").toString());

--- a/src/openambit/mainwindow.h
+++ b/src/openambit/mainwindow.h
@@ -78,6 +78,7 @@ private slots:
 
     void newerFirmwareExists(QByteArray fw_version);
     void movesCountAuth(bool authorized);
+    void showUploadError(QByteArray data);
 
     void logItemSelected(QListWidgetItem *current,QListWidgetItem *previous);
     void showContextMenuForLogItem(const QPoint &pos);


### PR DESCRIPTION
Sometimes when downloading moves from the watch (Ambit 2 in my case), there're data errors like invalid field ranges:

> Invalid CompressedSampleSets: Invalid EnergyConsumption: valid range is [0, 1000] kCal\/min

```
$ grep EnergyConsumpt ../../.openambit/log_75A509510F002000_2019_01_29_09_06_37.log
...
                <EnergyConsumption>29698</EnergyConsumption>
                <EnergyConsumption>29698</EnergyConsumption>
                <EnergyConsumption>72</EnergyConsumption>
                <EnergyConsumption>30466</EnergyConsumption>
                <EnergyConsumption>30466</EnergyConsumption>
```


In other cases, due to some race condition, the move is uploaded but no saved locally, so the next time you try to upload it, it fails.

All these errors are not displayed to the user, and thus we don't know the reason why a move is not uploaded in order to be able to fix/report it.