### PR TITLE
Memory cleanup

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -182,3 +182,9 @@ will use the latest and greatest(?) version.
 .. _Ubuntu: http://packages.ubuntu.com/search?keywords=openambit
 .. _OSWatershed.org: http://oswatershed.org/pkg/openambit
 .. _release: https://github.com/openambitproject/openambit/releases
+
+More information
+----------------
+
+Look at the wiki at https://github.com/openambitproject/openambit/wiki for
+more information.

--- a/README.rst
+++ b/README.rst
@@ -80,6 +80,10 @@ necessary packages:
 
 ``sudo apt-get install debhelper gcc g++ make cmake libusb-1.0-0-dev libudev-dev qtbase5-dev qttools5-dev-tools zlib1g-dev libpcap-dev libglib2.0-dev wireshark-dev qttools5-dev``
 
+Openambit also makes use of the hidapi library from https://github.com/signal11/hidapi
+The source is currently included, so no dependency needs to be installed
+for it.
+
 Build Procedure
 ---------------
 

--- a/src/example/ambitconsole.c
+++ b/src/example/ambitconsole.c
@@ -12,6 +12,7 @@ int main(int argc, char *argv[])
     ambit_object_t *ambit_object;
     ambit_device_status_t status;
     ambit_personal_settings_t settings;
+    memset(&settings, 0, sizeof(ambit_personal_settings_t));
 
     if (info) {
         printf("Device: %s, serial: %s\n", info->name, info->serial);

--- a/src/libambit/device_driver_ambit.c
+++ b/src/libambit/device_driver_ambit.c
@@ -193,11 +193,13 @@ static int log_read(ambit_object_t *object, ambit_log_skip_cb skip_cb, ambit_log
                         // Header was NOT skipped, break out!
                         read_pmem = true;
                         LOG_INFO("Found new entry, start reading log data");
+                        libambit_protocol_free(reply_data);
                         break;
                     }
                 }
                 else {
                     LOG_ERROR("Failed to parse log header");
+                    libambit_protocol_free(reply_data);
                     return -1;
                 }
                 libambit_protocol_free(reply_data);
@@ -242,6 +244,8 @@ static int log_read(ambit_object_t *object, ambit_log_skip_cb skip_cb, ambit_log
                         push_cb(userref, log_entry);
                     }
                     entries_read++;
+
+                    libambit_log_entry_free(log_entry);
                 }
             }
             else {
@@ -260,8 +264,6 @@ static int log_read(ambit_object_t *object, ambit_log_skip_cb skip_cb, ambit_log
         free(log_header.activity_name);
     }
     
-    // this is released somewhere else as well?!? libambit_log_entry_free(log_entry);
-
     return entries_read;
 }
 
@@ -334,6 +336,8 @@ static int sport_mode_write(ambit_object_t *object, ambit_sport_mode_device_sett
     if (data != NULL) {
         int dataLen = serialize_sport_mode_device_settings(ambit_device_settings, data);
         ret = libambit_pmem20_sport_mode_write(&object->driver_data->pmem20, data, dataLen, false);
+
+        free(data);
     }
 
     return ret;
@@ -357,6 +361,8 @@ static int app_data_write(ambit_object_t *object, ambit_sport_mode_device_settin
     if (data != NULL) {
         int dataLen = serialize_app_data(ambit_device_settings, ambit_apps, data);
         ret = libambit_pmem20_app_data_write(&object->driver_data->pmem20, data, dataLen, false);
+
+        free(data);
     }
 
     return ret;

--- a/src/libambit/device_driver_ambit3.c
+++ b/src/libambit/device_driver_ambit3.c
@@ -459,6 +459,8 @@ static int process_log_read_replies_gen1(ambit_object_t *object, libambit_sbem01
                             push_cb(userref, log_entry);
                         }
                         entries_read++;
+
+                        libambit_log_entry_free(log_entry);
                     }
                 }
                 else {
@@ -478,8 +480,6 @@ static int process_log_read_replies_gen1(ambit_object_t *object, libambit_sbem01
         }
     }
     
-    // is released somewhere else as well?!? libambit_log_entry_free(log_entry);
-
     return entries_read;
 }
 

--- a/src/libambit/device_driver_ambit_navigation.c
+++ b/src/libambit/device_driver_ambit_navigation.c
@@ -141,6 +141,7 @@ int ambit_navigation_waypoint_read(ambit_object_t *object, ambit_pack_waypoint_t
     for(x=0; x<(*way_point_count); ++x) {
 
         send_waypoint_data = malloc(sizeof(ambit_pack_waypoint_t));
+        memset(send_waypoint_data, 0, sizeof(ambit_pack_waypoint_t));
         send_data = malloc(sizeof(ambit_pack_waypoint_t));
 
         send_waypoint_data->index = htole16(x);

--- a/src/libambit/libambit.c
+++ b/src/libambit/libambit.c
@@ -351,8 +351,11 @@ void libambit_sport_mode_device_settings_free(ambit_sport_mode_device_settings_t
     if (settings->sport_modes != NULL) {
         for (i=0; i<settings->sport_modes_count; i++) {
             if (settings->sport_modes[i].display != NULL) {
-                if (settings->sport_modes[i].display->view != NULL) {
-                    free(settings->sport_modes[i].display->view);
+                int j;
+                for(j = 0;j < settings->sport_modes[i].displays_count;j++) {
+                    if (settings->sport_modes[i].display[j].view != NULL) {
+                        free(settings->sport_modes[i].display[j].view);
+                    }
                 }
                 free(settings->sport_modes[i].display);
             }
@@ -371,6 +374,8 @@ void libambit_sport_mode_device_settings_free(ambit_sport_mode_device_settings_t
         }
         free(settings->sport_mode_groups);
     }
+
+    free(settings);
 }
 
 ambit_sport_mode_device_settings_t *libambit_malloc_sport_mode_device_settings(void)
@@ -381,6 +386,7 @@ ambit_sport_mode_device_settings_t *libambit_malloc_sport_mode_device_settings(v
     ambit_device_settings->sport_mode_groups = NULL;
     ambit_device_settings->sport_mode_groups_count = 0;
     ambit_device_settings->app_ids_count = 0;
+    memset(ambit_device_settings->app_ids, 0, sizeof(ambit_device_settings->app_ids));
 
     return ambit_device_settings;
 }
@@ -431,6 +437,12 @@ bool libambit_malloc_sport_mode_groups(uint16_t count, ambit_sport_mode_device_s
 
 bool libambit_malloc_sport_mode_app_ids(uint16_t count, ambit_sport_mode_t *ambit_sport_mode)
 {
+    if(count == 0) {
+        ambit_sport_mode->apps_list = NULL;
+        ambit_sport_mode->apps_list_count = 0;
+        return false;
+    }
+
     ambit_apps_list_t *ambit_app_ids = (ambit_apps_list_t *)malloc(sizeof(ambit_apps_list_t) * count);
     if (ambit_app_ids != NULL) {
         ambit_sport_mode->apps_list = ambit_app_ids;
@@ -445,6 +457,12 @@ bool libambit_malloc_sport_mode_app_ids(uint16_t count, ambit_sport_mode_t *ambi
 
 bool libambit_malloc_sport_mode_displays(uint16_t count, ambit_sport_mode_t *ambit_sport_mode)
 {
+    if(count == 0) {
+        ambit_sport_mode->display = NULL;
+        ambit_sport_mode->displays_count = 0;
+        return false;
+    }
+
     ambit_sport_mode_display_t *ambit_displays = (ambit_sport_mode_display_t *)malloc(sizeof(ambit_sport_mode_display_t) * count);
     if (ambit_displays != NULL) {
         ambit_sport_mode->display = ambit_displays;
@@ -465,6 +483,12 @@ bool libambit_malloc_sport_mode_displays(uint16_t count, ambit_sport_mode_t *amb
 
 bool libambit_malloc_sport_mode_view(uint16_t count, ambit_sport_mode_display_t *ambit_displays)
 {
+    if(count == 0) {
+        ambit_displays->view = NULL;
+        ambit_displays->views_count = 0;
+        return false;
+    }
+
     uint16_t *ambit_views = (uint16_t *)malloc(sizeof(uint16_t) * count);
     if (ambit_views != NULL) {
         ambit_displays->view = ambit_views;

--- a/src/libambit/pmem20.c
+++ b/src/libambit/pmem20.c
@@ -585,12 +585,12 @@ int libambit_pmem20_data_write(libambit_pmem20_t *object, const uint32_t start_a
     size_t offset = 0;
 
     bufptrs[0] = data;
-    bufsizes = object->chunk_size;
+    bufsizes = datalen > object->chunk_size ? object->chunk_size : datalen;
 
     // Write first chunk
     ret = write_data_chunk(object->ambit_object, address, 1, bufptrs, &bufsizes);
     offset += bufsizes;
-    address += object->chunk_size;
+    address += bufsizes;
 
     // Write rest of the chunks
     while (ret == 0 && offset < datalen) {

--- a/src/libambit/protocol.c
+++ b/src/libambit/protocol.c
@@ -90,6 +90,7 @@ int libambit_protocol_command(ambit_object_t *object, uint16_t command, uint8_t 
 {
     int ret = 0;
     uint8_t buf[64];
+    memset(buf, 0, 64);
     int packet_count = 1;
     ambit_msg_header_t *msg = (ambit_msg_header_t *)buf;
     uint8_t packet_payload_len;
@@ -157,6 +158,8 @@ int libambit_protocol_command(ambit_object_t *object, uint16_t command, uint8_t 
                 reply_data_len -= packet_payload_len;
             }
             else {
+                libambit_protocol_free(*reply_data);
+
                 ret = -1;
             }
         }

--- a/src/movescount/sportmode.cpp
+++ b/src/movescount/sportmode.cpp
@@ -233,10 +233,10 @@ void CustomMode::toAmbitSettings(ambit_sport_mode_settings_t *settings)
 
 void CustomMode::toAmbitName(char ambitName[NAME_SIZE])
 {
-    const char *source = activityName.toLatin1().data();
+    const QByteArray &source = activityName.toLatin1();
     int strLen = activityName.length() < NAME_SIZE ? activityName.length() : NAME_SIZE;
     memset(ambitName, 0x00, NAME_SIZE);
-    memcpy(ambitName, source, strLen);
+    memcpy(ambitName, source.data(), strLen);
 }
 
 u_int16_t CustomMode::hrbeltAndPods()

--- a/src/movescount/sportmodegroup.cpp
+++ b/src/movescount/sportmodegroup.cpp
@@ -70,8 +70,8 @@ void CustomModeGroup::toAmbitData(ambit_sport_mode_group_t *ambitCustomModeGroup
 
 void CustomModeGroup::toAmbitName(char ambitName[GROUP_NAME_SIZE])
 {
-    const char *source = activityName.toLatin1().data();
+    const QByteArray &source = activityName.toLatin1();
     int strLen = activityName.length() < GROUP_NAME_SIZE ? activityName.length() : GROUP_NAME_SIZE;
     memset(ambitName, 0x00, GROUP_NAME_SIZE);
-    memcpy(ambitName, source, strLen);
+    memcpy(ambitName, source.data(), strLen);
 }


### PR DESCRIPTION
A number of changes in varoius places found while analyzing openambit with valgrind. 

Some are mostly necessary to avoid reports in Valgrind and should not cause an actual problem, but they do not harm anyway so better to have a clean Valgrind report to spot any newly introduced issues easily.