### PR TITLE
App-Data: Adjust how the byte-array is converted from JSON

### DIFF
--- a/src/movescount/movescountjson.cpp
+++ b/src/movescount/movescountjson.cpp
@@ -468,7 +468,10 @@ int MovesCountJSON::parseAppRulesReply(QByteArray &input, ambit_app_rules_t* amb
             appRulesId.append(entry["RuleID"].toUInt());
             QByteArray binary;
             foreach (QVariant binaryVar, entry["Binary"].toList()) {
-                binary.append(binaryVar.toChar());
+                binary.append(binaryVar.toInt(&ok));
+                if(!ok) {
+                    return -1;
+                }
             }
             appRulesData.append(binary);
         }


### PR DESCRIPTION
When reading the bytes from JSON the toChar() was always returning 0, by using toInt() it seems to work for me now!

This hopefully closes #190