### PR TITLE
Show a message-box if settings cannot be written

### DIFF
--- a/src/openambit/settingsdialog.h
+++ b/src/openambit/settingsdialog.h
@@ -41,12 +41,14 @@ public:
 
 signals:
     void settingsSaved();
+    void settingsError(QString msg);
 
 public slots:
     void changePage(QListWidgetItem *current, QListWidgetItem *previous);
     void accept();
     void showHideUserSettings();
-    
+    void showSettingsError(QString msg);
+
 private:
     void readSettings();
     void writeSettings();


### PR DESCRIPTION
Otherwise it seems that settings were saved correctly, but
they are actually not.

e.g. if the config file is write-only when created by a different
(root) user