### PR TITLE
Fix CMakeList of openambit-cli and unitest for windows build

### DIFF
--- a/src/openambit-cli/CMakeLists.txt
+++ b/src/openambit-cli/CMakeLists.txt
@@ -10,7 +10,11 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")
 
 find_package(libambit REQUIRED)
 find_package(Movescount REQUIRED)
+IF (!WIN32)
 find_package(UDev REQUIRED)
+ELSE (!WIN32)
+set(UDEV_LIBS "")
+ENDIF (!WIN32)
 find_package(Qt5Core REQUIRED)
 
 include(GNUInstallDirs)

--- a/src/unittest/CMakeLists.txt
+++ b/src/unittest/CMakeLists.txt
@@ -10,7 +10,11 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")
 
 find_package(libambit REQUIRED)
 find_package(Movescount REQUIRED)
+IF (!WIN32)
 find_package(UDev REQUIRED)
+ELSE (!WIN32)
+set(UDEV_LIBS "")
+ENDIF (!WIN32)
 find_package(Qt5Core REQUIRED)
 
 include(GNUInstallDirs)


### PR DESCRIPTION
Fixed CMakeLists of unittest and openambit-cli to enable build
under windows which does not have udev.