### PR TITLE
Include <sys/time.h>

### DIFF
--- a/src/libambit/pmem20.c
+++ b/src/libambit/pmem20.c
@@ -28,6 +28,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <stdio.h>
+#include <sys/time.h>
 
 /*
  * Local definitions


### PR DESCRIPTION
According to POSIX `struct timeval` is defined if <sys/time.h> is
included.
This fixes the build with musl, which is rather strict when it comes
to standards.