### PR TITLE
Strava uploader fix

### DIFF
--- a/tools/strava_upload.sh
+++ b/tools/strava_upload.sh
@@ -30,7 +30,7 @@ else
     OPENAMBIT_CLI=openambit-cli
 fi
 
-$OPENAMBIT_CLI --no-sync-sport-mode --no-sync-navigation $@ || exit 1
+$OPENAMBIT_CLI --no-sync-sport-mode --no-sync-navigation --no-sync-orbit $@ || exit 1
 
 # Get new number of logs
 nb_new_logs=`ls -l ~/.openambit/*.log|wc -l`

--- a/tools/stravauploader/strava_uploader.py
+++ b/tools/stravauploader/strava_uploader.py
@@ -97,6 +97,10 @@ def uploadMove(activity):
         r = requests.get(activty_url, headers=headers)
         resp = r.json()
 
+        if resp.get('error', ''):
+            print(resp['error'])
+            return (r.status_code, resp['error'])
+        
     if r.status_code == 200:
         print('New activity at https://www.strava.com/activities/{}'.format(resp['activity_id']))
         return (r.status_code, 'OK')


### PR DESCRIPTION
Fix strava uploader script by detecting error from server.
Disable orbit synchronization as it's not available anymore from movescount.